### PR TITLE
Bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ cd stackdriver-metrics-export
 2. Create the BigQuery tables
 Create a Dataset and then a table using the schema JSON files
 ```sh
+cd bigquery_schemas
 bq mk metric_export
 bq mk --table --time_partitioning_type=DAY metric_export.sd_metrics_export_fin ./bigquery_schema.json
 bq mk --table --time_partitioning_type=DAY metric_export.sd_metrics_stats ./bigquery_schema_stats_table.json
-bq mk --table metric_export.sd_metrics_stats ./bigquery_schema_params_table.json
+bq mk --table metric_export.sd_metrics_params ./bigquery_schema_params_table.json
 ```
 
 3. Replace the JSON token in the config.py files
@@ -50,19 +51,19 @@ echo "y" | gcloud app deploy
 If you already have a default App Engine app in your project, enter the following command.
 
 ```sh
-export LIST_METRICS_URL=$(gcloud app browse -s list-metrics)
+export LIST_METRICS_URL=$(gcloud app browse -s list-metrics --no-launch-browser)
 ```
 if this was your first App Engine app in your project, enter the following command. 
 
 ```sh
-export LIST_METRICS_URL=$(gcloud app browse)
+export LIST_METRICS_URL=$(gcloud app browse --no-launch-browser)
 ```
 
 Now, get the get_timeseries and write_metrics URLs and create the Pub/Sub topics and subscriptions
 
 ```sh
-export GET_TIMESERIES_URL=$(gcloud app browse -s get-timeseries)
-export WRITE_METRICS_URL=$(gcloud app browse -s write-metrics)
+export GET_TIMESERIES_URL=$(gcloud app browse -s get-timeseries --no-launch-browser)
+export WRITE_METRICS_URL=$(gcloud app browse -s write-metrics --no-launch-browser) 
 
 gcloud pubsub topics create metrics_export_start
 gcloud pubsub subscriptions create metrics_export_start_sub --topic metrics_export_start --ack-deadline=60 --message-retention-duration=10m --push-endpoint="$LIST_METRICS_URL/_ah/push-handlers/receive_message"
@@ -82,7 +83,7 @@ gcloud pubsub topics publish metrics_export_start --message "{\"token\": \"$TOKE
 
 You can send in all of the parameters using the following command
 ```sh
-gcloud pubsub topics publish metrics_export_start --message "{\"token\": \"$TOKEN\"}, \"start_time\": \"2019-03-13T17:30:00.000000Z\", \"end_time\":\"2019-03-13T17:40:00.000000Z\",\"aggregation_alignment_period\":\"3600s\"}"
+gcloud pubsub topics publish metrics_export_start --message "{\"token\": \"$TOKEN\", \"start_time\": \"2019-03-13T17:30:00.000000Z\", \"end_time\":\"2019-03-13T17:40:00.000000Z\",\"aggregation_alignment_period\":\"3600s\"}"
 ```
 
 6. Verify that the app is working appropriately by running the end-to-end testing

--- a/list_metrics/main.py
+++ b/list_metrics/main.py
@@ -206,18 +206,17 @@ def get_and_publish_metrics(message_to_publish, metadata):
                 metadata["msg_written_cnt"] = 1
                 metadata["msg_without_timeseries"] = 0
                 msgs_published += 1
+                # build a list of stats messages to write to BigQuery
+                if config.WRITE_BQ_STATS_FLAG:
+                    json_msg = build_bigquery_stats_message(
+                        message_to_publish, metadata
+                    )
+                    json_msg_list.append(json_msg)
             else:
                 logging.debug("Excluded the metric: {}".format(metric['name']))
                 msgs_excluded += 1
                 metadata["msg_written_cnt"] = 0
                 metadata["msg_without_timeseries"] = 1
-
-            # build a list of stats messages to write to BigQuery
-            if config.WRITE_BQ_STATS_FLAG:
-                json_msg = build_bigquery_stats_message(
-                    message_to_publish, metadata
-                )
-                json_msg_list.append(json_msg)
 
         # Write to pubsub if there is 1 or more 
         publish_metrics(pubsub_msg_list)


### PR DESCRIPTION
An issue was discovered whereby the app fails if the first metric from metricDescriptors is excluded.  Furthermore, a side effect is wrong stats are saved if a metric is excluded but the previous one wasn't, given that the scope of the message_to_publish variable is functionally global.  In this instance, the information from the previous metric is saved at least twice.